### PR TITLE
refactoring to use swiftmailer for email templating

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,8 @@ branches:
 
 matrix:
     allow_failures:
-        - php:
-            - nightly
-            - hhvm
+        - php: nightly
+        - php: hhvm
 
 before_script:
     - mkdir -p ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d && echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,15 @@ php:
     - 5.5
     - 5.6
     - 7.0
+    - 7.1
     - nightly
     - hhvm
+
+env:
+ - SYMFONY_VERSION=2.8.*
+ - SYMFONY_VERSION=3.0.*
+ - SYMFONY_VERSION=3.1.*
+ - SYMFONY_VERSION=3.2.*
 
 branches:
     only:
@@ -13,11 +20,10 @@ branches:
         - /^\d+\.\d+$/
 
 matrix:
-    include:
-        - php: 5.5
-          env: SYMFONY_VERSION=2.8.*
     allow_failures:
-        - php: nightly
+        - php:
+            - nightly
+            - hhvm
 
 before_script:
     - mkdir -p ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d && echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini

--- a/Domain/MonitorMessage.php
+++ b/Domain/MonitorMessage.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: cjohnson
+ * Date: 5/18/17
+ * Time: 1:15 PM
+ */
+
+namespace JMose\CommandSchedulerBundle\Domain;
+
+class MonitorMessage
+{
+    /**
+     * @var $commandName string The name of the command which failed
+     */
+    private $commandName;
+    /**
+     * @var $commandLastReturnCode int The return code of the command which failed
+     */
+    private $commandLastReturnCode;
+    /**
+     * @var $commandLocked boolean A boolean which says if the command is locked or not
+     */
+    private $commandLocked;
+    /**
+     * @var $commandLastExecuted \DateTime The date and time the command was last executed
+     */
+    private $commandLastExecuted;
+
+    public function __construct($commandName, $commandLastReturnCode, $commandLocked, $commandLastExecuted)
+    {
+        $this->setCommandName($commandName);
+        $this->setCommandLastReturnCode($commandLastReturnCode);
+        $this->setCommandLocked($commandLocked);
+        $this->setCommandLastExecuted($commandLastExecuted);
+    }
+
+    /**
+     * @return string
+     */
+    public function getCommandName()
+    {
+        return $this->commandName;
+    }
+
+    /**
+     * @param string $commandName
+     */
+    public function setCommandName($commandName)
+    {
+        $this->commandName = $commandName;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCommandLastReturnCode()
+    {
+        return $this->commandLastReturnCode;
+    }
+
+    /**
+     * @param int $commandLastReturnCode
+     */
+    public function setCommandLastReturnCode($commandLastReturnCode)
+    {
+        $this->commandLastReturnCode = $commandLastReturnCode;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isCommandLocked()
+    {
+        return $this->commandLocked;
+    }
+
+    /**
+     * @param bool $commandLocked
+     */
+    public function setCommandLocked($commandLocked)
+    {
+        $this->commandLocked = $commandLocked;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getCommandLastExecuted()
+    {
+        return $this->commandLastExecuted;
+    }
+
+    /**
+     * @param \DateTime $commandLastExecuted
+     */
+    public function setCommandLastExecuted(\DateTime $commandLastExecuted)
+    {
+        $this->commandLastExecuted = $commandLastExecuted;
+    }
+
+    public function __toString()
+    {
+        return sprintf("%s: returncode %s, locked: %s, last execution: %s\n", $this->getCommandName(), $this->getCommandLastReturnCode(), $this->isCommandLocked(), $this->getCommandLastExecuted()->format('Y-m-d H:i'));
+    }
+}

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -131,6 +131,10 @@ This can easily be done by using standard overrides in Symfony, as described [he
 
 In your project, you'll want to copy the `Navbar:navbar:html.twig` template into `app/Resources/JMoseCommandSchedulerBundle/views/Navbar/navbar.html.twig`.  Any changes to the file in this location will take precedence over the bundle's template file.
 
+### 6 - Override the notification emails
+
+You can override the notification email template by providing your own version of `error.html.twig` and `noerror.html.twig` in `app/Resources/JMoseCommandSchedulerBundle/views/Emails/`.
+
 Usage
 ============
 

--- a/Resources/views/Emails/error.html.twig
+++ b/Resources/views/Emails/error.html.twig
@@ -1,0 +1,4 @@
+{% for monitorMessage in messages %}
+    {# @var monitorMessage \Jmose\CommandSchedulerBundle\Domain\MonitorMessage #}
+    {{ monitorMessage.getCommandName }}: {{ monitorMessage.getCommandLastReturnCode }}, locked: {{ monitorMessage.isCommandLocked }}, last execution: {{ monitorMessage.getCommandLastExecuted|date }}</br>
+{% endfor %}

--- a/Resources/views/Emails/noerror.html.twig
+++ b/Resources/views/Emails/noerror.html.twig
@@ -1,0 +1,1 @@
+No errors found.

--- a/Tests/App/AppKernel.php
+++ b/Tests/App/AppKernel.php
@@ -16,6 +16,7 @@ class AppKernel extends Kernel
             new Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
             new Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle(),
             new Liip\FunctionalTestBundle\LiipFunctionalTestBundle(),
+            new Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle(),
 
             new JMose\CommandSchedulerBundle\JMoseCommandSchedulerBundle(),
         );

--- a/Tests/App/config/config_test.yml
+++ b/Tests/App/config/config_test.yml
@@ -39,7 +39,11 @@ jmose_command_scheduler:
     lock_timeout: 300
     excluded_command_namespaces:
         - scheduler
+    monitor_mail: ['test@test.com']
 
 liip_functional_test:
     cache_sqlite_db: true
     command_decoration: false
+
+swiftmailer:
+    disable_delivery: true

--- a/Tests/Command/MonitorCommandTest.php
+++ b/Tests/Command/MonitorCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace JMose\CommandSchedulerBundle\Tests\Command;
 
+use JMose\CommandSchedulerBundle\Command\MonitorCommand;
 use Liip\FunctionalTestBundle\Test\WebTestCase;
 
 /**
@@ -80,6 +81,48 @@ class MonitorCommandTest extends WebTestCase
         );
 
         $this->assertStringStartsWith('No errors found.', $output);
+    }
+
+    /**
+     * @group unit
+     */
+    public function testSendErrorMails()
+    {
+        $templatingMock = $this->getMockBuilder(Symfony\Bundle\TwigBundle\TwigEngine::class)->disableOriginalConstructor()->setMethods(['render'])->getMock();
+        $templatingMock->expects($this->once())->method('render')->willReturn("The Email Body");
+
+        $containerMock = $this->getMockBuilder(ContainerInterface::class)->disableOriginalConstructor()->setMethods(['get'])->getMock();
+        $containerMock->expects($this->once())->method('get')->willReturn($templatingMock);
+
+        $monitorCommandMock = $this->getMockBuilder(MonitorCommand::class)->disableOriginalConstructor()->setMethods(['getContainer'])->getMock();
+        $monitorCommandMock->expects($this->once())->method('getContainer')->willReturn($containerMock);
+
+        $swiftMailerMock = $this->getMockBuilder(\Swift_Mailer::class)->disableOriginalConstructor()->setMethods([])->getMock();
+        $swiftMailerMock->expects($this->once())->method('send');
+
+        $monitorCommandMock->setMailer($swiftMailerMock);
+        $monitorCommandMock->sendErrorMails(array());
+    }
+
+    /**
+     * @group unit
+     */
+    public function testSendNoErrorMails()
+    {
+        $templatingMock = $this->getMockBuilder(Symfony\Bundle\TwigBundle\TwigEngine::class)->disableOriginalConstructor()->setMethods(['render'])->getMock();
+        $templatingMock->expects($this->once())->method('render')->willReturn("The Email Body");
+
+        $containerMock = $this->getMockBuilder(ContainerInterface::class)->disableOriginalConstructor()->setMethods(['get'])->getMock();
+        $containerMock->expects($this->once())->method('get')->willReturn($templatingMock);
+
+        $monitorCommandMock = $this->getMockBuilder(MonitorCommand::class)->disableOriginalConstructor()->setMethods(['getContainer'])->getMock();
+        $monitorCommandMock->expects($this->once())->method('getContainer')->willReturn($containerMock);
+
+        $swiftMailerMock = $this->getMockBuilder(\Swift_Mailer::class)->disableOriginalConstructor()->setMethods([])->getMock();
+        $swiftMailerMock->expects($this->once())->method('send');
+
+        $monitorCommandMock->setMailer($swiftMailerMock);
+        $monitorCommandMock->sendNoErrorMails();
     }
 
 }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,9 @@
         "twig/twig": "~1.15",
         "doctrine/orm": "~2.2,>=2.2.3,<2.6",
         "doctrine/doctrine-bundle": "~1.0",
-        "mtdowling/cron-expression": "~1.0"
+        "mtdowling/cron-expression": "~1.0",
+        "symfony/swiftmailer-bundle": "^2.3.10",
+        "swiftmailer/swiftmailer": "~5.4"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.4",


### PR DESCRIPTION
This allows customization of the email templates sent for errors and non-error notices.
I also updated travis to get a full matrix of the supported php/symfony versions