### PR TITLE
Added scheduler daemon

### DIFF
--- a/Command/StartSchedulerCommand.php
+++ b/Command/StartSchedulerCommand.php
@@ -1,0 +1,88 @@
+<?php
+namespace JMose\CommandSchedulerBundle\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Code originally taken from https://github.com/Cron/Symfony-Bundle/blob/2.1.0/Command/CronStartCommand.php
+ * License: MIT (according to https://github.com/Cron/Symfony-Bundle/blob/2.1.0/LICENSE)
+ * Original author: Alexander Lokhman <alex.lokhman@gmail.com>
+ *
+ * Adaption to CommandSchedulerBundle by Christoph Singer <singer@webagentur72.de>
+ *
+ */
+class StartSchedulerCommand extends Command
+{
+    const PID_FILE = '.cron-pid';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->setName('scheduler:start')
+            ->setDescription('Starts command scheduler')
+            ->addOption('blocking', 'b', InputOption::VALUE_NONE, 'Run in blocking mode.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        if ($input->getOption('blocking')) {
+            $output->writeln(sprintf('<info>%s</info>', 'Starting command scheduler in blocking mode.'));
+            $this->scheduler($output->isVerbose() ? $output : new NullOutput(), null);
+
+            return 0;
+        }
+
+        if (!extension_loaded('pcntl')) {
+            throw new \RuntimeException('This command needs the pcntl extension to run.');
+        }
+
+        $pidFile = sys_get_temp_dir().DIRECTORY_SEPARATOR.self::PID_FILE;
+
+        if (-1 === $pid = pcntl_fork()) {
+            throw new \RuntimeException('Unable to start the cron process.');
+        } elseif (0 !== $pid) {
+            if (false === file_put_contents($pidFile, $pid)) {
+                throw new \RuntimeException('Unable to create process file.');
+            }
+
+            $output->writeln(sprintf('<info>%s</info>', 'Command scheduler started in non-blocking mode...'));
+
+            return 0;
+        }
+
+        if (-1 === posix_setsid()) {
+            throw new \RuntimeException('Unable to set the child process as session leader.');
+        }
+
+        $this->scheduler(new NullOutput(), $pidFile);
+    }
+
+    private function scheduler(OutputInterface $output, $pidFile)
+    {
+        $input = new ArrayInput([]);
+
+        $console = $this->getApplication();
+        $command = $console->find('scheduler:execute');
+
+        while (true) {
+            $now = microtime(true);
+            usleep((60 - ($now % 60) + (int) $now - $now) * 1e6);
+
+            if (null !== $pidFile && !file_exists($pidFile)) {
+                break;
+            }
+
+            $command->run($input, $output);
+        }
+    }
+}

--- a/Command/StopSchedulerCommand.php
+++ b/Command/StopSchedulerCommand.php
@@ -1,0 +1,48 @@
+<?php
+namespace JMose\CommandSchedulerBundle\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Code originally taken from https://github.com/Cron/Symfony-Bundle/blob/2.1.0/Command/CronStopCommand.php
+ * License: MIT (according to https://github.com/Cron/Symfony-Bundle/blob/2.1.0/LICENSE)
+ * Original author: Alexander Lokhman <alex.lokhman@gmail.com>
+ *
+ * Adaption to CommandSchedulerBundle by Christoph Singer <singer@webagentur72.de>
+ *
+ */
+class StopSchedulerCommand extends Command
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->setName('scheduler:stop')
+            ->setDescription('Stops command scheduler');
+    }
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $pidFile = sys_get_temp_dir().DIRECTORY_SEPARATOR.StartSchedulerCommand::PID_FILE;
+        if (!file_exists($pidFile)) {
+            return 0;
+        }
+        if (!extension_loaded('pcntl')) {
+            throw new \RuntimeException('This command needs the pcntl extension to run.');
+        }
+        if (!posix_kill(file_get_contents($pidFile), SIGINT)) {
+            if (!unlink($pidFile)) {
+                throw new \RuntimeException('Unable to stop scheduler.');
+            }
+            $output->writeln(sprintf('<comment>%s</comment>', 'Unable to kill command scheduler process. Scheduler will be stopped before the next run.'));
+            return 0;
+        }
+        unlink($pidFile);
+        $output->writeln(sprintf('<info>%s</info>', 'Command scheduler is stopped.'));
+    }
+}

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -49,3 +49,9 @@ services:
             - "%jmose_command_scheduler.doctrine_manager%"
             - "%jmose_command_scheduler.lock_timeout%"
         tags: [console.command]
+
+    JMose\CommandSchedulerBundle\Command\StartSchedulerCommand:
+        tags: [console.command]
+
+    JMose\CommandSchedulerBundle\Command\StopSchedulerCommand:
+        tags: [console.command]

--- a/Tests/Command/StartStopSchedulerCommandTest.php
+++ b/Tests/Command/StartStopSchedulerCommandTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace JMose\CommandSchedulerBundle\Tests\Command;
+
+use JMose\CommandSchedulerBundle\Command\StartSchedulerCommand;
+use Liip\FunctionalTestBundle\Test\WebTestCase;
+
+
+class StartStopSchedulerCommandTest extends WebTestCase
+{
+
+    /**
+     * Test scheduler:start and scheduler:stop
+     */
+    public function testStartAndStopScheduler()
+    {
+        //DataFixtures create 4 records
+        $this->loadFixtures(
+            array(
+                'JMose\CommandSchedulerBundle\Fixtures\ORM\LoadScheduledCommandData'
+            )
+        );
+
+        $pidFile = sys_get_temp_dir().DIRECTORY_SEPARATOR.StartSchedulerCommand::PID_FILE;
+
+
+        $output = $this->runCommand('scheduler:start');
+        $this->assertStringStartsWith('Command scheduler started in non-blocking mode...', $output);
+        $this->assertFileExists($pidFile);
+
+        $output = $this->runCommand('scheduler:stop');
+        $this->assertStringStartsWith('Command scheduler is stopped.', $output);
+        $this->assertFileNotExists($pidFile);
+    }
+
+}

--- a/composer.json
+++ b/composer.json
@@ -26,12 +26,16 @@
         "symfony/validator": "^3.4|^4.0"
     },
     "require-dev": {
+        "ext-pcntl": "*",
         "phpunit/phpunit": "^5.7",
         "php-coveralls/php-coveralls": "^2.0",
         "doctrine/doctrine-fixtures-bundle": "^3.0.0",
         "liip/functional-test-bundle": "^1.9",
         "symfony/css-selector": "^3.4|^4.0",
         "symfony/security-bundle": "^3.4|^4.0"
+    },
+    "suggest": {
+        "ext-pcntl": "For using the scheduler daemon"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR adds two commands  `scheduler:start` and `scheduler:stop` managing a daemon process that will call `scheduler:execute` every minute. So it is possible to use the scheduler without setting up a cron job.