### PR TITLE
Make tests run in SF4 using v2 of liip/functional-test-bundle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
         - php: 7.1
           env: SYMFONY_VERSION=3.4.*
         - php: 7.1
-          env: SYMFONY_VERSION=4.0.*
+          env: SYMFONY_VERSION=4.1.*
         - php: 7.2
           env: SYMFONY_VERSION=3.4.*
         - php: 7.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,13 @@ matrix:
         - php: 7.2
           env: SYMFONY_VERSION=3.4.*
         - php: 7.2
-          env: SYMFONY_VERSION=4.2.*
+          env: SYMFONY_VERSION=^4.2
         - php: 7.3
           env: SYMFONY_VERSION=3.4.*
         - php: 7.3
-          env: SYMFONY_VERSION=4.2.*
+          env: SYMFONY_VERSION=^4.2
         - php: nightly
-          env: SYMFONY_VERSION=4.2.*
+          env: SYMFONY_VERSION=^4.2
 
     allow_failures:
         - php: nightly
@@ -32,7 +32,7 @@ branches:
 before_script:
     - mkdir -p ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d && echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
     - composer self-update
-    - sh -c 'if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/symfony=$SYMFONY_VERSION; fi;'
+    - sh -c 'if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/framework-bundle=$SYMFONY_VERSION symfony/console=$SYMFONY_VERSION; fi;'
     - composer update --prefer-dist
 
 script:

--- a/Tests/App/config/config_test.yml
+++ b/Tests/App/config/config_test.yml
@@ -40,5 +40,13 @@ jmose_command_scheduler:
         - scheduler
 
 liip_functional_test:
-    cache_sqlite_db: true
+#    cache_sqlite_db: true
     command_decoration: false
+
+services:
+    JMose\CommandSchedulerBundle\Fixtures\ORM\LoadScheduledCommandData:
+        class: JMose\CommandSchedulerBundle\Fixtures\ORM\LoadScheduledCommandData
+        tags:
+            -   doctrine.fixture.orm
+
+

--- a/Tests/Command/ExecuteCommandTest.php
+++ b/Tests/Command/ExecuteCommandTest.php
@@ -3,6 +3,7 @@
 namespace JMose\CommandSchedulerBundle\Tests\Command;
 
 use Liip\FunctionalTestBundle\Test\WebTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
 
 /**
  * Class ExecuteCommandTest
@@ -24,6 +25,9 @@ class ExecuteCommandTest extends WebTestCase
         );
 
         $output = $this->runCommand('scheduler:execute');
+        if ($output instanceof CommandTester) {
+            $output = $output->getDisplay();
+        }
 
         $this->assertStringStartsWith('Start : Execute all scheduled command', $output);
         $this->assertRegExp('/debug:container should be executed/', $output);
@@ -32,6 +36,9 @@ class ExecuteCommandTest extends WebTestCase
         $this->assertRegExp('/Execute : debug:router/', $output);
 
         $output = $this->runCommand('scheduler:execute');
+        if ($output instanceof CommandTester) {
+            $output = $output->getDisplay();
+        }
         $this->assertRegExp('/Nothing to do/', $output);
     }
 
@@ -54,9 +61,16 @@ class ExecuteCommandTest extends WebTestCase
             )
         );
 
+        if ($output instanceof CommandTester) {
+            $output = $output->getDisplay();
+        }
+
         $this->assertEquals('', $output);
 
         $output = $this->runCommand('scheduler:execute');
+        if ($output instanceof CommandTester) {
+            $output = $output->getDisplay();
+        }
         $this->assertRegExp('/Nothing to do/', $output);
     }
 
@@ -79,6 +93,10 @@ class ExecuteCommandTest extends WebTestCase
             )
         );
 
+        if ($output instanceof CommandTester) {
+            $output = $output->getDisplay();
+        }
+        
         $this->assertStringStartsWith('Start : Dump all scheduled command', $output);
         $this->assertRegExp('/Command debug:container should be executed/', $output);
         $this->assertRegExp('/Immediately execution asked for : debug:router/', $output);

--- a/Tests/Command/MonitorCommandTest.php
+++ b/Tests/Command/MonitorCommandTest.php
@@ -3,6 +3,7 @@
 namespace JMose\CommandSchedulerBundle\Tests\Command;
 
 use Liip\FunctionalTestBundle\Test\WebTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
 
 /**
  * Class MonitorCommandTest
@@ -46,7 +47,9 @@ class MonitorCommandTest extends WebTestCase
                 '--dump' => true
             )
         );
-
+        if ($output instanceof CommandTester) {
+            $output = $output->getDisplay();
+        }
         $this->assertRegExp('/two:/', $output);
         $this->assertRegExp('/four:/', $output);
     }
@@ -78,7 +81,9 @@ class MonitorCommandTest extends WebTestCase
                 '--dump' => true
             )
         );
-
+        if ($output instanceof CommandTester) {
+            $output = $output->getDisplay();
+        }
         $this->assertStringStartsWith('No errors found.', $output);
     }
 

--- a/Tests/Command/UnlockCommandTest.php
+++ b/Tests/Command/UnlockCommandTest.php
@@ -4,6 +4,7 @@ namespace JMose\CommandSchedulerBundle\Tests\Command;
 
 use JMose\CommandSchedulerBundle\Entity\ScheduledCommand;
 use Liip\FunctionalTestBundle\Test\WebTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
 
 /**
  * Class UnlockCommandTest
@@ -40,7 +41,9 @@ class UnlockCommandTest extends WebTestCase {
         $output = $this->runCommand(
                 'scheduler:unlock', ['--all' => true]
         );
-
+        if ($output instanceof CommandTester) {
+            $output = $output->getDisplay();
+        }
         $this->assertRegExp('/"two"/', $output);
         $this->assertNotRegExp('/"one"/', $output);
         $this->assertNotRegExp('/"three"/', $output);
@@ -64,7 +67,9 @@ class UnlockCommandTest extends WebTestCase {
         $output = $this->runCommand(
                 'scheduler:unlock', ['name' => 'two']
         );
-
+        if ($output instanceof CommandTester) {
+            $output = $output->getDisplay();
+        }
         $this->assertRegExp('/"two"/', $output);
 
         $this->em->clear();
@@ -86,7 +91,9 @@ class UnlockCommandTest extends WebTestCase {
         $output = $this->runCommand(
                 'scheduler:unlock', ['name' => 'two', '--lock-timeout' =>  3 * 24 * 60 * 60 ]
         );
-
+        if ($output instanceof CommandTester) {
+            $output = $output->getDisplay();
+        }
         $this->assertRegExp('/Skipping/', $output);
         $this->assertRegExp('/"two"/', $output);
 

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "phpunit/phpunit": "^5.7",
         "php-coveralls/php-coveralls": "^2.0",
         "doctrine/doctrine-fixtures-bundle": "^3.0.0",
-        "liip/functional-test-bundle": "^1.9",
+        "liip/functional-test-bundle": "^1.9|^2.0.0-alpha17",
         "symfony/css-selector": "^3.4|^4.0",
         "symfony/security-bundle": "^3.4|^4.0"
     },


### PR DESCRIPTION
Currently tests with symfony4 fail because liip/functional-test-bundle v1 does not support it. There is a stable v3 version of this bundle but it requires major refactoring of the tests, and tests would not be backwards compatible to v1 which is needed for PHP 5.6. So the solution was to go with functionalTestBundle v2 which is currently in alpha state. It required only minor changes in the test setup that are backward compatible to v1. So the travis tests hopefully now run on PHP 5.6/SF 3.4/FunctionalTestBundle 1.9 as well as PHP7.x/SF 4.x/FunctionalTestBundle 2.x.