### PR TITLE
Fix deprecation warning for Symfony >= 4.1 _and_ fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,24 +2,20 @@ language: php
 
 matrix:
     include:
-        - php: 5.6
-          env: SYMFONY_VERSION=3.4.*
-        - php: 7.0
-          env: SYMFONY_VERSION=3.4.*
         - php: 7.1
           env: SYMFONY_VERSION=3.4.*
+        - php: 7.2
+          env: SYMFONY_VERSION=3.4.*
+        - php: 7.3
+          env: SYMFONY_VERSION=3.4.*
         - php: 7.1
-          env: SYMFONY_VERSION=4.0.*
+          env: SYMFONY_VERSION=4.3.*
         - php: 7.2
-          env: SYMFONY_VERSION=3.4.*
-        - php: 7.2
-          env: SYMFONY_VERSION=4.2.*
+          env: SYMFONY_VERSION=4.3.*
         - php: 7.3
-          env: SYMFONY_VERSION=3.4.*
-        - php: 7.3
-          env: SYMFONY_VERSION=4.2.*
+          env: SYMFONY_VERSION=4.3.*
         - php: nightly
-          env: SYMFONY_VERSION=4.2.*
+          env: SYMFONY_VERSION=4.3.*
 
     allow_failures:
         - php: nightly

--- a/Controller/DetailController.php
+++ b/Controller/DetailController.php
@@ -49,7 +49,7 @@ class DetailController extends BaseController
         $scheduledCommand = new ScheduledCommand();
 
         return $this->forward(
-            'JMoseCommandSchedulerBundle:Detail:index',
+            self::class . '::indexAction',
             [
                 'scheduledCommand' => $scheduledCommand,
             ]
@@ -68,7 +68,7 @@ class DetailController extends BaseController
             ->find($scheduledCommandId);
 
         return $this->forward(
-            'JMoseCommandSchedulerBundle:Detail:index',
+            self::class . '::indexAction',
             [
                 'scheduledCommand' => $scheduledCommand,
             ]
@@ -115,7 +115,7 @@ class DetailController extends BaseController
         
         // Redirect to indexAction with the form object that has validation errors
         return $this->forward(
-            'JMoseCommandSchedulerBundle:Detail:index',
+            self::class . '::indexAction',
             [
                 'scheduledCommand' => $scheduledCommand,
                 'scheduledCommandForm' => $scheduledCommandForm,

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The following table shows the compatibilities of different versions of the bundl
 
 | Version                                                                                 | Symfony     | PHP    |
 | --------------------------------------------------------------------------------------- |  ---------- | ------ |
-| [2.x](https://github.com/J-Mose/CommandSchedulerBundle/tree/master)                     | ^3.4\|^4    | >=5.6  |
+| [2.x](https://github.com/J-Mose/CommandSchedulerBundle/tree/master)                     | ^3.4\|^4.3  | >=7.1  |
 | [1.2.x](https://github.com/J-Mose/CommandSchedulerBundle/tree/1.2) (unmaintained)       | ^2.8\|^3.0  | >=5.5  |
 | [1.1.x](https://github.com/J-Mose/CommandSchedulerBundle/tree/1.1) (unmaintained)       | ^2.3        | >=5.3  |
 

--- a/Tests/App/AppKernel.php
+++ b/Tests/App/AppKernel.php
@@ -17,6 +17,7 @@ class AppKernel extends Kernel
             new \Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle(),
             new \Liip\FunctionalTestBundle\LiipFunctionalTestBundle(),
             new \JMose\CommandSchedulerBundle\JMoseCommandSchedulerBundle(),
+            new \Liip\TestFixturesBundle\LiipTestFixturesBundle(),
         );
     }
 

--- a/Tests/App/config/config_test.yml
+++ b/Tests/App/config/config_test.yml
@@ -40,5 +40,13 @@ jmose_command_scheduler:
         - scheduler
 
 liip_functional_test:
-    cache_sqlite_db: true
     command_decoration: false
+
+liip_test_fixtures:
+    cache_db:
+        sqlite: liip_test_fixtures.services_database_backup.sqlite
+
+services:
+    JMose\CommandSchedulerBundle\Fixtures\ORM\:
+        resource: '../../../Fixtures/ORM/*'
+        tags: ['doctrine.fixture.orm']

--- a/Tests/Command/ExecuteCommandTest.php
+++ b/Tests/Command/ExecuteCommandTest.php
@@ -3,6 +3,7 @@
 namespace JMose\CommandSchedulerBundle\Tests\Command;
 
 use Liip\FunctionalTestBundle\Test\WebTestCase;
+use Liip\TestFixturesBundle\Test\FixturesTrait;
 
 /**
  * Class ExecuteCommandTest
@@ -10,6 +11,7 @@ use Liip\FunctionalTestBundle\Test\WebTestCase;
  */
 class ExecuteCommandTest extends WebTestCase
 {
+    use FixturesTrait;
 
     /**
      * Test scheduler:execute without option
@@ -23,7 +25,7 @@ class ExecuteCommandTest extends WebTestCase
             )
         );
 
-        $output = $this->runCommand('scheduler:execute');
+        $output = $this->runCommand('scheduler:execute')->getDisplay();
 
         $this->assertStringStartsWith('Start : Execute all scheduled command', $output);
         $this->assertRegExp('/debug:container should be executed/', $output);
@@ -31,7 +33,7 @@ class ExecuteCommandTest extends WebTestCase
         $this->assertRegExp('/Immediately execution asked for : debug:router/', $output);
         $this->assertRegExp('/Execute : debug:router/', $output);
 
-        $output = $this->runCommand('scheduler:execute');
+        $output = $this->runCommand('scheduler:execute')->getDisplay();
         $this->assertRegExp('/Nothing to do/', $output);
     }
 
@@ -52,11 +54,11 @@ class ExecuteCommandTest extends WebTestCase
             array(
                 '--no-output' => true
             )
-        );
+        )->getDisplay();
 
         $this->assertEquals('', $output);
 
-        $output = $this->runCommand('scheduler:execute');
+        $output = $this->runCommand('scheduler:execute')->getDisplay();
         $this->assertRegExp('/Nothing to do/', $output);
     }
 
@@ -77,7 +79,7 @@ class ExecuteCommandTest extends WebTestCase
             array(
                 '--dump' => true
             )
-        );
+        )->getDisplay();
 
         $this->assertStringStartsWith('Start : Dump all scheduled command', $output);
         $this->assertRegExp('/Command debug:container should be executed/', $output);

--- a/Tests/Command/MonitorCommandTest.php
+++ b/Tests/Command/MonitorCommandTest.php
@@ -3,6 +3,7 @@
 namespace JMose\CommandSchedulerBundle\Tests\Command;
 
 use Liip\FunctionalTestBundle\Test\WebTestCase;
+use Liip\TestFixturesBundle\Test\FixturesTrait;
 
 /**
  * Class MonitorCommandTest
@@ -10,6 +11,8 @@ use Liip\FunctionalTestBundle\Test\WebTestCase;
  */
 class MonitorCommandTest extends WebTestCase
 {
+    use FixturesTrait;
+
     /**
      * @var \Doctrine\ORM\EntityManager
      */
@@ -45,7 +48,7 @@ class MonitorCommandTest extends WebTestCase
             array(
                 '--dump' => true
             )
-        );
+        )->getDisplay();
 
         $this->assertRegExp('/two:/', $output);
         $this->assertRegExp('/four:/', $output);
@@ -77,7 +80,7 @@ class MonitorCommandTest extends WebTestCase
             array(
                 '--dump' => true
             )
-        );
+        )->getDisplay();
 
         $this->assertStringStartsWith('No errors found.', $output);
     }

--- a/Tests/Command/UnlockCommandTest.php
+++ b/Tests/Command/UnlockCommandTest.php
@@ -4,12 +4,15 @@ namespace JMose\CommandSchedulerBundle\Tests\Command;
 
 use JMose\CommandSchedulerBundle\Entity\ScheduledCommand;
 use Liip\FunctionalTestBundle\Test\WebTestCase;
+use Liip\TestFixturesBundle\Test\FixturesTrait;
 
 /**
  * Class UnlockCommandTest
  * @package JMose\CommandSchedulerBundle\Tests\Command
  */
 class UnlockCommandTest extends WebTestCase {
+
+    use FixturesTrait;
 
     /**
      * @var \Doctrine\ORM\EntityManager
@@ -39,7 +42,7 @@ class UnlockCommandTest extends WebTestCase {
         // One command is locked in fixture (2), another have a -1 return code as lastReturn (4)
         $output = $this->runCommand(
                 'scheduler:unlock', ['--all' => true]
-        );
+        )->getDisplay();
 
         $this->assertRegExp('/"two"/', $output);
         $this->assertNotRegExp('/"one"/', $output);
@@ -63,7 +66,7 @@ class UnlockCommandTest extends WebTestCase {
         // One command is locked in fixture (2), another have a -1 return code as lastReturn (4)
         $output = $this->runCommand(
                 'scheduler:unlock', ['name' => 'two']
-        );
+        )->getDisplay();
 
         $this->assertRegExp('/"two"/', $output);
 
@@ -85,7 +88,7 @@ class UnlockCommandTest extends WebTestCase {
         // One command is locked in fixture with last execution two days ago (2), another have a -1 return code as lastReturn (4)
         $output = $this->runCommand(
                 'scheduler:unlock', ['name' => 'two', '--lock-timeout' =>  3 * 24 * 60 * 60 ]
-        );
+        )->getDisplay();
 
         $this->assertRegExp('/Skipping/', $output);
         $this->assertRegExp('/"two"/', $output);

--- a/Tests/Controller/DetailControllerTest.php
+++ b/Tests/Controller/DetailControllerTest.php
@@ -3,6 +3,7 @@
 namespace JMose\CommandSchedulerBundle\Tests\Controller;
 
 use Liip\FunctionalTestBundle\Test\WebTestCase;
+use Liip\TestFixturesBundle\Test\FixturesTrait;
 
 /**
  * Class DetailControllerTest
@@ -10,6 +11,7 @@ use Liip\FunctionalTestBundle\Test\WebTestCase;
  */
 class DetailControllerTest extends WebTestCase
 {
+    use FixturesTrait;
 
     /**
      * Test "Create a new command" button.

--- a/Tests/Controller/ListControllerTest.php
+++ b/Tests/Controller/ListControllerTest.php
@@ -3,6 +3,7 @@
 namespace JMose\CommandSchedulerBundle\Tests\Controller;
 
 use Liip\FunctionalTestBundle\Test\WebTestCase;
+use Liip\TestFixturesBundle\Test\FixturesTrait;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -11,6 +12,7 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class ListControllerTest extends WebTestCase
 {
+    use FixturesTrait;
 
     /**
      * @var \Doctrine\ORM\EntityManager

--- a/composer.json
+++ b/composer.json
@@ -29,9 +29,10 @@
         "phpunit/phpunit": "^5.7",
         "php-coveralls/php-coveralls": "^2.0",
         "doctrine/doctrine-fixtures-bundle": "^3.0.0",
-        "liip/functional-test-bundle": "^1.9",
+        "liip/functional-test-bundle": "^3.2",
         "symfony/css-selector": "^3.4|^4.0",
-        "symfony/security-bundle": "^3.4|^4.0"
+        "symfony/security-bundle": "^3.4|^4.0",
+        "liip/test-fixtures-bundle": "^1.0.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": "^5.6|>=7.0.8",
+        "php": "^7.1",
         "symfony/console": "^3.4|^4.0",
         "doctrine/orm": "^2.5.11",
         "doctrine/doctrine-bundle": "^1.6.10",


### PR DESCRIPTION
Fix for: `User Deprecated: Referencing controllers with JMoseCommandSchedulerBundle:Detail:index is deprecated since Symfony 4.1, use "JMose\CommandSchedulerBundle\Controller\DetailController::indexAction" instead.`

While at it, I fixed the travis/CI builds too, by upgrading `liip/functional-test-bundle`. This has a side effect though: `liip/functional-test-bundle` and `liip/test-fixtures-bundle` require `php >= 7.1`. While this bundle remains to be working between `php 5.6` and `php 7.1`, at this moment testing isn't. I'd suggest to merge this change to a 2.0 version of this bundle, and set the required php-version to `php >= 7.1` there as well. See https://www.php.net/supported-versions.php for current supported php versions.
