### PR TITLE
Fixed: returning other then int in Command::executed is deprecated since SF 4.4 and will throw an error since SF 5.0

### DIFF
--- a/Command/ExecuteCommand.php
+++ b/Command/ExecuteCommand.php
@@ -95,7 +95,7 @@ class ExecuteCommand extends Command
     /**
      * @param InputInterface $input
      * @param OutputInterface $output
-     * @return int|null|void
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -111,7 +111,7 @@ class ExecuteCommand extends Command
                 ' not found or not writable. You should override `log_path` in your config.yml'.'</error>'
             );
 
-            return;
+            return 1;
         }
 
         $commands = $this->em->getRepository(ScheduledCommand::class)->findEnabledCommand();
@@ -155,6 +155,8 @@ class ExecuteCommand extends Command
         if (true === $noneExecution) {
             $output->writeln('Nothing to do.');
         }
+
+        return 0;
     }
 
     /**

--- a/Command/MonitorCommand.php
+++ b/Command/MonitorCommand.php
@@ -97,7 +97,7 @@ class MonitorCommand extends Command
         if (!$this->dumpMode && count($this->receiver) === 0) {
             $output->writeln('Please add receiver in configuration');
 
-            return;
+            return 1;
         }
 
         // Fist, get all failed or potential timeout
@@ -132,6 +132,8 @@ class MonitorCommand extends Command
                 $this->sendMails('No errors found.');
             }
         }
+
+        return 0;
     }
 
     /**

--- a/Command/StartSchedulerCommand.php
+++ b/Command/StartSchedulerCommand.php
@@ -65,6 +65,8 @@ class StartSchedulerCommand extends Command
         }
 
         $this->scheduler(new NullOutput(), $pidFile);
+
+        return 0;
     }
 
     private function scheduler(OutputInterface $output, $pidFile)

--- a/Command/StopSchedulerCommand.php
+++ b/Command/StopSchedulerCommand.php
@@ -44,5 +44,7 @@ class StopSchedulerCommand extends Command
         }
         unlink($pidFile);
         $output->writeln(sprintf('<info>%s</info>', 'Command scheduler is stopped.'));
+
+        return 0;
     }
 }


### PR DESCRIPTION
Fixes: #157 