### PR TITLE
Indicate of the name of the default yaml configuration file

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -100,7 +100,7 @@ See the [Usage](#usage) section to have more information
 
 ### 4 - Available configuration
 
-Here is the default bundle configuration.
+Here is the default bundle configuration. The flex recipe will create the scheduler.yaml file in your packages directory where you can change the base configuration.
 
 ```yaml
 jmose_command_scheduler:


### PR DESCRIPTION
Added a quick description of where the yaml file is as I didn't realize it was created for me and couldn't get the expected results. Lost a bit of time trying to understand if it was a bug until I found the file.