### PR TITLE
Standardize `\DateTimeInterface::ATOM` as date format in command outputs

### DIFF
--- a/Command/ExecuteCommand.php
+++ b/Command/ExecuteCommand.php
@@ -143,7 +143,7 @@ class ExecuteCommand extends Command
                 $output->writeln(
                     'Command <comment>'.$command->getCommand().
                     '</comment> should be executed - last execution : <comment>'.
-                    $command->getLastExecution()->format('d/m/Y H:i:s').'.</comment>'
+                    $command->getLastExecution()->format(\DateTimeInterface::ATOM).'.</comment>'
                 );
 
                 if (!$input->getOption('dump')) {

--- a/Command/MonitorCommand.php
+++ b/Command/MonitorCommand.php
@@ -114,7 +114,7 @@ class MonitorCommand extends Command
                     $command->getName(),
                     $command->getLastReturnCode(),
                     $command->getLocked(),
-                    $command->getLastExecution()->format('Y-m-d H:i')
+                    $command->getLastExecution()->format(\DateTimeInterface::ATOM)
                 );
             }
 


### PR DESCRIPTION
|Q            |A     |
|---          |---   |
|Branch       |master|
|Bug fix?     |no    |
|New feature? |no    |
|BC breaks?   |no    |
|Deprecations?|no    |
|Tests pass?  |yes   |
|Fixed tickets|n/a   |
|License      |MIT   |
|Doc PR       |n/a   |

See [`DateTimeInterface::ATOM`](https://www.php.net/manual/en/class.datetimeinterface.php#datetime.constants.atom).